### PR TITLE
Remove extra call stats header

### DIFF
--- a/res/layout/call_stats_detail.xml
+++ b/res/layout/call_stats_detail.xml
@@ -87,14 +87,6 @@
 
     </LinearLayout>
 
-    <TextView
-        android:id="@+id/header_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:singleLine="true"
-        android:textAppearance="?android:attr/textAppearanceMedium"
-        android:textColor="?attr/call_log_header_color" />
-
     <!-- The actual details -->
     <LinearLayout
         android:layout_width="match_parent"

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -21,7 +21,6 @@
         <attr name="call_log_primary_background_color" format="color" />
         <attr name="call_log_secondary_text_color" format="color" />
         <attr name="call_log_secondary_background_color" format="color" />
-        <attr name="call_log_header_color" format="color" />
     </declare-styleable>
 
     <declare-styleable name="VoicemailStatus">

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -65,7 +65,6 @@
         <item name="call_log_primary_background_color">#000000</item>
         <item name="call_log_secondary_text_color">@color/dialtacts_secondary_text_color</item>
         <item name="call_log_secondary_background_color">#333333</item>
-        <item name="call_log_header_color">#33b5e5</item>
         <!-- VoicemailStatus -->
         <item name="call_log_voicemail_status_height">48dip</item>
         <item name="call_log_voicemail_status_background_color">#262626</item>
@@ -131,7 +130,6 @@
         <!-- CallLog -->
         <item name="call_log_primary_background_color">#FFFFFF</item>
         <item name="call_log_secondary_background_color">#FFFFFF</item>
-        <item name="call_log_header_color">#FFFFFF</item>
         <!-- VoicemailStatus -->
         <item name="call_log_voicemail_status_height">48dip</item>
         <item name="call_log_voicemail_status_background_color">#262626</item>

--- a/src/com/android/dialer/callstats/CallStatsDetailActivity.java
+++ b/src/com/android/dialer/callstats/CallStatsDetailActivity.java
@@ -59,7 +59,6 @@ public class CallStatsDetailActivity extends Activity {
     private CallDetailHeader mCallDetailHeader;
     private Resources mResources;
 
-    private TextView mHeaderTextView;
     private TextView mTotalSummary;
     private TextView mTotalDuration;
     private TextView mInSummary;
@@ -103,7 +102,6 @@ public class CallStatsDetailActivity extends Activity {
                 new PhoneNumberUtilsWrapper());
         mContactInfoHelper = new ContactInfoHelper(this, GeoUtil.getCurrentCountryIso(this));
 
-        mHeaderTextView = (TextView) findViewById(R.id.header_text);
         mTotalSummary = (TextView) findViewById(R.id.total_summary);
         mTotalDuration = (TextView) findViewById(R.id.total_duration);
         mInSummary = (TextView) findViewById(R.id.in_summary);
@@ -162,7 +160,6 @@ public class CallStatsDetailActivity extends Activity {
         mNumber = mData.number.toString();
 
         // Set the details header, based on the first phone call.
-        mCallStatsDetailHelper.setCallStatsDetailHeader(mHeaderTextView, mData);
         mCallDetailHeader.updateViews(mData);
         mCallDetailHeader.loadContactPhotos(mData, ContactPhotoManager.TYPE_DEFAULT);
         invalidateOptionsMenu();

--- a/src/com/android/dialer/callstats/CallStatsDetailHelper.java
+++ b/src/com/android/dialer/callstats/CallStatsDetailHelper.java
@@ -127,21 +127,6 @@ public class CallStatsDetailHelper {
         }
     }
 
-    public void setCallStatsDetailHeader(TextView nameView, CallStatsDetails details) {
-        final CharSequence nameText;
-        final CharSequence displayNumber = mPhoneNumberHelper.getDisplayNumber(
-                details.number, details.numberPresentation,
-                mResources.getString(R.string.recentCalls_addToContact));
-
-        if (TextUtils.isEmpty(details.name)) {
-            nameText = displayNumber;
-        } else {
-            nameText = details.name;
-        }
-
-        nameView.setText(nameText);
-    }
-
     public static String getCallCountString(Resources res, long count) {
         return res.getQuantityString(R.plurals.call, (int) count, (int) count);
     }


### PR DESCRIPTION
Call stats activity displays contact name/number in white text on an off-white
background.  This change removes the view because that information is already
present in the call detail header anyway.

Change-Id: I5df0bfd277179674e22ad4b6870d89a3140334e8