### PR TITLE
Do not reload smart dial database twice in DialtactsActivity.

### DIFF
--- a/src/com/android/dialer/DialtactsActivity.java
+++ b/src/com/android/dialer/DialtactsActivity.java
@@ -495,7 +495,6 @@ public class DialtactsActivity extends TransactionSafeActivity implements View.O
         }
         mFirstLaunch = false;
         prepareVoiceSearchButton();
-        mDialerDatabaseHelper.startSmartDialUpdateThread();
         updateFloatingActionButtonControllerAlignment(false /* animate */);
         setConferenceDialButtonImage(false);
         setConferenceDialButtonVisibility(true);


### PR DESCRIPTION
In fe57f36d843b3c973aa44621602a57d0b1e208a7 different logic was
introduced to reload the smart dial DB when the locale changes. This
added a duplicate call to update the smart dial db if the locale has not
changed. Remove the duplicate call that existed before this patch.

Change-Id: Ibd8aff58537b101883bf078090230144676633f5